### PR TITLE
Do not silently ignore wrong input

### DIFF
--- a/src/digraph.spec.ts
+++ b/src/digraph.spec.ts
@@ -280,7 +280,9 @@ describe("Directed Graph Implementation", () => {
         const vertexA: Vertex = { id: "a", adjacentTo: [], body: {} };
 
         digraph.addVertices(vertexA);
-        digraph.addEdge({ from: vertexA.id, to: vertexA.id });
+        expect(() => {
+          digraph.addEdge({ from: vertexA.id, to: vertexA.id });
+        }).to.throw(Error, 'Cannot create a self-referencing edge: "A -> A"');
 
         expect(vertexA.adjacentTo).to.deep.equal([]);
       });

--- a/src/digraph.ts
+++ b/src/digraph.ts
@@ -70,7 +70,7 @@ export class DiGraph<Vertex extends VertexDefinition<VertexBody>> {
 
   public addEdge({ from, to }: { from: VertexId; to: VertexId }): void {
     if (from === to) {
-      return;
+      throw new Error('Cannot create a self-referencing edge: "A -> A"');
     }
 
     const [fromVertex, toVertex] = [


### PR DESCRIPTION
Was using the lib for some of my devs, and discovered this (was trying to add a self referencing edge). I think, there must be an error thrown instead of the silent ignore.